### PR TITLE
Shortened comment for data-privly-accept-resize

### DIFF
--- a/privly.safariextension/scripts/privly.js
+++ b/privly.safariextension/scripts/privly.js
@@ -372,8 +372,7 @@ var privly = {
       "scrolling":"no",
       "overflow":"hidden",
       "data-privly-display":"true",
-      "data-privly-accept-resize":"true", //Custom attribute indicating this iframe
-      //is eligible for being resized by its contents
+      "data-privly-accept-resize":"true", //Indicates this iframe is resize eligible
       "src":applicationUrl,
       "id":"ifrm" + id, //The id and the name are the same so that the iframe can be
       "name":"ifrm" + id //uniquely identified and resized


### PR DESCRIPTION
Shortened comment for data-privly-accept-resize
This is to keep the privly.js script standardised between the extensions. This has already been done in the Chrome extension, https://github.com/privly/privly-chrome/commit/33207f1a09518a83c7e815150050cbd435c482d8