### PR TITLE
New Message option added to Context Menu

### DIFF
--- a/privly.safariextension/Info.plist
+++ b/privly.safariextension/Info.plist
@@ -17,7 +17,19 @@
 	<key>CFBundleVersion</key>
 	<string>0.1.0</string>
 	<key>Chrome</key>
-	<dict/>
+	<dict>
+		<key>Context Menu Items</key>
+		<array>
+			<dict>
+				<key>Identifier</key>
+				<string>new_message</string>
+				<key>Title</key>
+				<string>New Message</string>
+			</dict>
+		</array>
+		<key>Global Page</key>
+		<string>privly.html</string>
+	</dict>
 	<key>Content</key>
 	<dict>
 		<key>Scripts</key>

--- a/privly.safariextension/privly.html
+++ b/privly.safariextension/privly.html
@@ -1,0 +1,14 @@
+<!DOCTYPE HTML>
+<html>
+  <head>
+
+    <title>Privly Safari Extension</title>
+
+    <!-- include scripts -->
+    <script type="text/javascript" src="scripts/handle_command_event.js"></script>
+
+  </head>
+  <body>
+
+  </body>
+</html>

--- a/privly.safariextension/scripts/handle_command_event.js
+++ b/privly.safariextension/scripts/handle_command_event.js
@@ -1,0 +1,21 @@
+/**
+ * @fileOverview This file handles the command event. Command events
+ * are generated when the user clicks an extension's toolbar item
+ * or chooses an extension's menu item (including contextual menu item).
+ * More about command events can be read about at
+ * https://developer.apple.com/library/safari/documentation/Tools/Conceptual/SafariExtensionGuide/SafariExtensionGuide.pdf
+ */
+
+/**
+ * Performs the specific action based on the command event.
+ *
+ * @param event the command event that is dispatched
+ *
+ */
+function performCommand(event) {
+  if (event.command === "new_message") {
+    safari.application.activeBrowserWindow.openTab().url = safari.extension.baseURI + "privly-applications/Message/new.html";
+  }
+}
+
+safari.application.addEventListener("command", performCommand, false);


### PR DESCRIPTION
The New Message option is now added to the Context Menu. On clicking the New Message option, a new tab opens which has a URL, privly-applications/Message/new.html and lets users post new message.