### PR TITLE
Updated first_run background script to reflect latest changes in options and glyph icons

### DIFF
--- a/privly.safariextension/privly.html
+++ b/privly.safariextension/privly.html
@@ -4,7 +4,14 @@
 
     <title>Privly Safari Extension</title>
 
+    <!-- Tells context_messenger.js that this is the background script -->
+    <meta id="is-background-script">
+
     <!-- include scripts -->
+    <script type="text/javascript" src="privly-applications/shared/javascripts/storage.js"></script>
+    <script type="text/javascript" src="privly-applications/shared/javascripts/context_messenger.js"></script>
+    <script type="text/javascript" src="privly-applications/shared/javascripts/options.js"></script>
+    <script type="text/javascript" src="privly-applications/shared/javascripts/glyph.js"></script>
     <script type="text/javascript" src="privly-applications/shared/javascripts/local_storage.js"></script>
     <script type="text/javascript" src="scripts/background_scripts/first_run.js"></script>
     <script type="text/javascript" src="scripts/background_scripts/handle_command_event.js"></script>

--- a/privly.safariextension/scripts/background_scripts/first_run.js
+++ b/privly.safariextension/scripts/background_scripts/first_run.js
@@ -22,29 +22,25 @@ var firstRun = {
   initializeApplication: function() {
 
     // Open the first run page only on new installations.
-    var postingDomain = ls.getItem("posting_content_server_url");
+    var postingDomain = Privly.storage.get("posting_content_server_url");
 
     if (postingDomain === undefined || postingDomain === null) {
-      ls.setItem("posting_content_server_url", "https://privlyalpha.org");
+      Privly.storage.set("posting_content_server_url", "https://privlyalpha.org");
     }
 
     // Initialize the spoofing glyph
     // The generated string is not cryptographically secure and should not be used
     // for anything other than the glyph.
-    if (ls.getItem("glyph_cells") === undefined) {
+    if (Privly.glyph.getGlyph() === null) {
 
       // Dissable the posting button by default if the user already has
       // the extension installed.
-      if (ls.getItem("posting_content_server_url") !== undefined) {
-        ls.setItem("Options:DissableButton", "true");
+      if (Privly.storage.get("posting_content_server_url") !== undefined) {
+        Privly.storage.set("Options:DissableButton", "true");
       }
 
-      ls.setItem("glyph_color", Math.floor(Math.random()*16777215).toString(16));
-      var glyph_cells = ((Math.random() < 0.5) ? "false" : "true");
-      for(var i = 0; i < 14; i++) {
-        glyph_cells += "," + ((Math.random() < 0.5) ? "false" : "true");
-      }
-      ls.setItem("glyph_cells", glyph_cells);
+      // Generate a new glyph for the current user
+      Privly.glyph.generateGlyph();
     }
 
     /* istanbul ignore if */
@@ -61,14 +57,21 @@ var firstRun = {
   checkFirstRun: function() {
 
     // Set the expected version to compare against the stored version
-    // todo, set this dynamically
-    var runningVersion = "0.1.0";
-    var lastRunVersion = ls.getItem("version");
+    // Set the expected version dynamically if possible
+
+    var runningVersion;
+    /* istanbul ignore if */
+    if (typeof safari !== "undefined" && safari.extension !== undefined) {
+      runningVersion = safari.extension.displayVersion;
+    } else {
+      runningVersion = "0.1.0";
+    }
+    var lastRunVersion = Privly.storage.get("version");
 
     if (lastRunVersion !== runningVersion) {
 
       // Set this first or else it will open repeatedly on new Xul overlays
-      ls.setItem("version", runningVersion);
+      Privly.storage.set("version", runningVersion);
       firstRun.initializeApplication();
     }
   }

--- a/test/first_run.js
+++ b/test/first_run.js
@@ -11,8 +11,9 @@ describe ("First Run Suite", function() {
     // The firstRun.checkFirstRun() is called in first_run.js
     expect(ls.getItem("version")).toMatch("0.1.0");
     expect(ls.getItem("posting_content_server_url")).toBeDefined();
-    expect(ls.getItem("glyph_color")).toBeDefined();
-    expect(ls.getItem("glyph_cells")).toBeDefined();
+    expect(ls.getItem("options/glyph")).toBeDefined();
+    expect(ls.getItem("options/glyph").cells).toBeDefined();
+    expect(ls.getItem("options/glyph").color).toBeDefined();
   });
 
 });


### PR DESCRIPTION
Changes made in the PR:
* The privly-applications submodule has been updated to commit, https://github.com/privly/privly-applications/commit/2061c130480dc5a2f2ce16e912dedc7017a71921
* The js files, `storage.js`, `context_messenger.js`, `options.js` and `glyph.js` has been included in the global page now.
* In the `first_run.js` background script, `ls.getItem()` and `ls.setItem()` has been replaced by `Privly.storage.get()` and `Privly.storage.set()`
* For checking and setting the glyph icons, `Privly.glyph` has been used
* The `runningVersion` has been dynamically set now when possible
* The `first_run.js` background script test has been updated