### PR TITLE
Use Privly.options.setPrivlyButtonEnabled

### DIFF
--- a/privly.safariextension/scripts/background_scripts/first_run.js
+++ b/privly.safariextension/scripts/background_scripts/first_run.js
@@ -36,7 +36,7 @@ var firstRun = {
       // Dissable the posting button by default if the user already has
       // the extension installed.
       if (Privly.storage.get("posting_content_server_url") !== undefined) {
-        Privly.storage.set("Options:DissableButton", "true");
+        Privly.options.setPrivlyButtonEnabled(false);
       }
 
       // Generate a new glyph for the current user

--- a/test/first_run.js
+++ b/test/first_run.js
@@ -9,11 +9,13 @@ describe ("First Run Suite", function() {
   it("localStorage key and values are initialized properly", function() {
 
     // The firstRun.checkFirstRun() is called in first_run.js
-    expect(ls.getItem("version")).toMatch("0.1.0");
-    expect(ls.getItem("posting_content_server_url")).toBeDefined();
-    expect(ls.getItem("options/glyph")).toBeDefined();
-    expect(ls.getItem("options/glyph").cells).toBeDefined();
-    expect(ls.getItem("options/glyph").color).toBeDefined();
+    expect(Privly.storage.get("version")).toMatch("0.1.0");
+    expect(Privly.storage.get("posting_content_server_url")).toBeDefined();
+    expect(Privly.storage.get("options/glyph")).toBeDefined();
+    expect(Privly.storage.get("options/glyph").cells).toBeDefined();
+    expect(Privly.storage.get("options/glyph").color).toBeDefined();
+    expect(Privly.options.isPrivlyButtonEnabled()).toBe(false);
+    expect(Privly.storage.get("posting_content_server_url")).toMatch("https://privlyalpha.org");
   });
 
 });


### PR DESCRIPTION
Changes made in the PR:
* Updated the privly-application submodule to commit https://github.com/privly/privly-applications/commit/32721a543de692d0e61dac31f7df25824327e3a1
* Uses `Privly.options.setPrivlyButtonEnabled` to set the privly button visibility. For the privly button visibility, the local storage variable `options/privlyButton` is now used. This can be seen at, https://github.com/privly/privly-applications/blob/gsoc-develop/shared/javascripts/options.js#L180
* Updated the `first_run.js` test to make use of the `Privly` variable