### PR TITLE
Mirror localStorage of PRIVLY_APPLICATION in background page

### DIFF
--- a/privly.safariextension/privly.html
+++ b/privly.safariextension/privly.html
@@ -17,6 +17,7 @@
     <script type="text/javascript" src="scripts/background_scripts/handle_command_event.js"></script>
     <script type="text/javascript" src="scripts/background_scripts/modal_button.js"></script>
     <script type="text/javascript" src="scripts/background_scripts/reading_process.js"></script>
+    <script type="text/javascript" src="scripts/background_scripts/mirror_local_storage.js"></script>
 
   </head>
   <body>

--- a/privly.safariextension/scripts/background_scripts/mirror_local_storage.js
+++ b/privly.safariextension/scripts/background_scripts/mirror_local_storage.js
@@ -1,0 +1,30 @@
+/**
+ * @fileOverview This file mirrors the localStorage of the
+ * PRIVLY_APPLICATION pages in the background page. Whenever,
+ * the localStorage is updated in the PRIVLY_APPLICATION pages,
+ * a message is sent to the background page. This file checks
+ * for the updates in the localStorage and updates the background
+ * page localStorage.
+ */
+
+/**
+ * Make appropriate updates to localStorage of background page.
+ *
+ * @param event the message that is received
+ *
+ */
+function updateLocalStorage(event) {
+  if (event.name === "privlyMessage" &&
+      typeof event.message.body !== "undefined") {
+        var payload = event.message.body;
+        if (payload.action === "storage/set") {
+          Privly.storage.set(payload.key, payload.value);
+        } else if (payload.action === "storage/remove") {
+          Privly.storage.remove(payload.key);
+        }
+  }
+}
+
+if (typeof safari !== "undefined" && safari.application !== undefined) {
+  safari.application.addEventListener("message", updateLocalStorage);
+}

--- a/test/mirror_local_storage.js
+++ b/test/mirror_local_storage.js
@@ -1,0 +1,44 @@
+/**
+ * @fileOverview mirror_local_storage.js Gives testing code for updating
+ * the localStorage functionality. This spec is managed by the Jasmine
+ * testing library.
+ */
+
+describe ("Mirror Local Storage Suite", function() {
+
+  it("localStorage key and value is set properly", function() {
+
+    // Build the message for setting localStorage key, value
+    var setMessage = {
+      name: "privlyMessage",
+      message: {
+        body: {
+          action: "storage/set",
+          key: "privlySafariExtension",
+          value: "True"
+        }
+      }
+    };
+
+    updateLocalStorage(setMessage);
+    expect(Privly.storage.get(setMessage.message.body.key)).toMatch(setMessage.message.body.value);
+  });
+
+  it("localStorage key and value is removed properly", function() {
+
+    // Build the message for removing localStorage key, value
+    var removeMessage = {
+      name: "privlyMessage",
+      message: {
+        body: {
+          action: "storage/remove",
+          key: "privlySafariExtension"
+        }
+      }
+    };
+
+    updateLocalStorage(removeMessage);
+    expect(Privly.storage.get(removeMessage.message.body.key)).toBeNull();
+  });
+
+});

--- a/test/run_each.sh
+++ b/test/run_each.sh
@@ -48,7 +48,7 @@ runTest () {
 commonScripts="vendor/jquery.min.js,shared/javascripts/*.js"
 
 # Each line below executes the scripts in order in the context of the browsers.
-runTest "$commonScripts,../scripts/background_scripts/first_run.js,../../test/first_run.js,../scripts/popover.js,../../test/popover.js"
+runTest "$commonScripts,../scripts/background_scripts/first_run.js,../../test/first_run.js,../scripts/popover.js,../../test/popover.js,../scripts/background_scripts/mirror_local_storage.js,../../test/mirror_local_storage.js"
 
 if [ ! $ISFAIL -eq 0 ]
 then


### PR DESCRIPTION
**Changes made in the PR:**
Both the background page and the `PRIVLY_APPLICATION` pages have a different localStorage. Thus, if any changes are made in the `PRIVLY_APPLICATION` pages, a message is sent to the background page with the changes. Hence, the same changes need to be made in the background page too by parsing the message.
The option changes that are supported are:
* options/privlyButton
* options/injection
* options/whitelist/domains
* options/whitelist/regexp
* options/contentServer/url
* options/glyph