### PR TITLE
Check if iframe injection is allowed by CSP

### DIFF
--- a/privly.safariextension/CSP_iframe.html
+++ b/privly.safariextension/CSP_iframe.html
@@ -1,0 +1,6 @@
+<html>
+  <head>
+  </head>
+  <body>
+  </body>
+</html>


### PR DESCRIPTION
Changes made in the PR:
* Added a variable `privly.blockedByCSP` which tells us whether iframe injection is allowed by CSP for a host page
* Gives the iframe 2s to load and then, checks whether iframe injection is allowed. If not, stops the content script.

Fixed https://github.com/privly/privly-safari/issues/34