### PR TITLE
Allow the extension for automatic future updates

### DIFF
--- a/privly.safariextension/Info.plist
+++ b/privly.safariextension/Info.plist
@@ -74,7 +74,7 @@
 	<key>Description</key>
 	<string>The official Privly Safari browser extension.</string>
 	<key>DeveloperIdentifier</key>
-	<string>34B3M269R6</string>
+	<string>NW49B9S472</string>
 	<key>ExtensionInfoDictionaryVersion</key>
 	<string>1.0</string>
 	<key>Permissions</key>
@@ -87,6 +87,8 @@
 			<string>All</string>
 		</dict>
 	</dict>
+	<key>Update Manifest URL</key>
+	<string>https://raw.githubusercontent.com/privly/privly-safari/master/privly.safariextension/Update.plist</string>
 	<key>Website</key>
 	<string>http://priv.ly</string>
 </dict>

--- a/privly.safariextension/Update.plist
+++ b/privly.safariextension/Update.plist
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>Extension Updates</key>
+	<array>
+		<dict>
+			<key>CFBundleIdentifier</key>
+			<string>com.privly.privly</string>
+			<key>Developer Identifier</key>
+			<string>NW49B9S472</string>
+			<key>CFBundleVersion</key>
+			<string>0.1.0</string>
+			<key>CFBundleShortVersionString</key>
+			<string>0.1.0</string>
+			<key>URL</key>
+			<string>https://priv.ly/assets/extensions/safari/privly.safariextz</string>
+		</dict>
+	</array>
+</dict>
+</plist>


### PR DESCRIPTION
Changes done in the PR:
* Added Update.plist. This file allows for automatic future updates of the extension.

Note: This is also required for uploading the extension to the Safari Extensions Gallery.